### PR TITLE
Convert playlist name spaces to underscores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"hautelook/phpass": "0.3.*",
 		"mobiledetect/mobiledetectlib": "2.7.*",
 		"zendframework/zend-http": "2.2.*",
-        "behat/transliterator": "1.0.*"
+		"behat/transliterator": "1.0.*"
 
     }
 }

--- a/src/protected/controllers/MovieController.php
+++ b/src/protected/controllers/MovieController.php
@@ -117,9 +117,9 @@ class MovieController extends MediaController
 			throw new PageNotFoundException();
 
 		$links = VideoLibrary::getVideoLinks($movieDetails->file);
-        $playlist = new M3UPlaylist();
-        $playlist->name = $movieDetails->title.' ('.$movieDetails->year.')';
-        $playlist->sanitizeFilename();
+		$playlist = new M3UPlaylist();
+		$playlist->name = $movieDetails->title.' ('.$movieDetails->year.')';
+		$playlist->sanitizeFilename();
 		$linkCount = count($links);
 
 		foreach ($links as $k=> $link)

--- a/src/protected/controllers/TvShowController.php
+++ b/src/protected/controllers/TvShowController.php
@@ -171,8 +171,8 @@ class TvShowController extends MediaController
 		
 		// Construct the playlist
 		$playlist = new M3UPlaylist();
-        $playlist->name = $episode->showtitle.' - '.$episodeString;
-        $playlist->sanitizeFilename();
+		$playlist->name = $episode->showtitle.' - '.$episodeString;
+		$playlist->sanitizeFilename();
 		$links = VideoLibrary::getVideoLinks($episode->file);
 		$linkCount = count($links);
 

--- a/src/protected/models/M3UPlaylist.php
+++ b/src/protected/models/M3UPlaylist.php
@@ -16,12 +16,12 @@ class M3UPlaylist
 	/**
 	 * @var array the playlist items
 	 */
-    private $_items = array();
+	private $_items = array();
 
-    /**
-     * Filename
-     */
-    public $name;
+	/**
+	 * Filename
+	 */
+	public $name;
 
 	/**
 	 * Adds an item to the playlist
@@ -51,12 +51,12 @@ class M3UPlaylist
 		return ob_get_clean();
 	}
 
-    /**
-     * Sanitize filename for use in POSIX systems
-     */
-    public function sanitizeFilename()
-    {
-        $this->name = Transliterator::transliterate($this->name);
-    }
+	/**
+	 * Sanitize filename for use in POSIX systems
+	 */
+	public function sanitizeFilename()
+	{
+		$this->name = Transliterator::transliterate($this->name);
+	}
 
 }


### PR DESCRIPTION
Spaces in filenames can lead to problems when opening in Unix machines. In particular, xdg-open will not recognise spaces and open each word as an individual file. This PR replaces spaces with underscores.
