### PR TITLE
Add a "date added" column to the movie list

### DIFF
--- a/src/protected/models/VideoLibrary.php
+++ b/src/protected/models/VideoLibrary.php
@@ -18,7 +18,7 @@ class VideoLibrary
 	 * @var string[] default properties for movies
 	 */
 	private static $_defaultMovieProperties = array(
-		'year', 'genre', 'thumbnail', 'rating', 'runtime', 'playcount'
+		'year', 'genre', 'thumbnail', 'rating', 'runtime', 'playcount', 'dateadded'
 	);
 
 	/**

--- a/src/protected/models/json/Movie.php
+++ b/src/protected/models/json/Movie.php
@@ -30,6 +30,11 @@ class Movie extends File implements IStreamable
 	public $director;
 
 	/**
+	 * @var string the date the movie was added to the library 
+	 */
+	public $dateadded;
+
+	/**
 	 * @var int
 	 */
 	private $_votes;
@@ -76,4 +81,11 @@ class Movie extends File implements IStreamable
 		return 'http://www.imdb.com/title/'.$this->imdbnumber.'/';
 	}
 
+	/**
+	 * @return string
+	 */
+	public function getDateAdded()
+	{
+		return $this->dateadded;
+	}
 }

--- a/src/protected/widgets/results/ResultListMovies.php
+++ b/src/protected/widgets/results/ResultListMovies.php
@@ -18,6 +18,7 @@ class ResultListMovies extends ResultList
 			$this->getGenreColumn(),
 			$this->getRatingColumn(),
 			$this->getRuntimeColumn(),
+			$this->getDateAddedColumn(),
 		);
 	}
 
@@ -53,4 +54,20 @@ class ResultListMovies extends ResultList
 		);
 	}
 
+
+	/**
+	 * Returns the column definition for the dateadded column
+	 * @return array
+	 */
+	private function getDateAddedColumn()
+	{
+		return [
+			'name'   => 'dateadded',
+			'header' => Yii::t('MovieList', 'Date added'),
+			'value'  => function ($data) {
+				/** @var Movie $data */
+				echo $data->getDateAdded();
+			},
+		];
+	}
 }


### PR DESCRIPTION
This allows us to sort by date added, which is the only way to get all movies in recently added order, since the recently added movies API doesn't allow fetching more than X latest movies.

Closes #296