### PR TITLE
Don't blindly call makeSortable() on the data provider, only do it where it makes sense

### DIFF
--- a/src/protected/controllers/MediaController.php
+++ b/src/protected/controllers/MediaController.php
@@ -186,22 +186,4 @@ abstract class MediaController extends Controller
 		$this->render('//videoLibrary/browserPlayer', array(
 			'items'=>array($item)));
 	}
-
-	/**
-	 * Renders an index page based on the specified list of media items and 
-	 * the filter form. If the results contain a single item the user is 
-	 * redirected to that item's details page instead.
-	 * @param Media[] $items the media items
-	 * @param VideoFilterForm $filterForm the filter form
-	 */
-	protected function renderIndex($items, $filterForm)
-	{
-		if (count($items) === 1 && $filterForm->name === $items[0]->label)
-			$this->redirect(array('details', 'id'=>$items[0]->getId()));
-
-		$this->render('index', array(
-			'dataProvider'=>new LibraryDataProvider($items),
-			'filterForm'=>$filterForm));
-	}
-
 }

--- a/src/protected/controllers/MovieController.php
+++ b/src/protected/controllers/MovieController.php
@@ -24,18 +24,34 @@ class MovieController extends MediaController
 		$filterForm = new MovieFilterForm();
 		$movies = VideoLibrary::getMovies($filterForm->buildRequestParameters());
 
-		$this->renderIndex($movies, $filterForm);
+		// Redirect to the details page if there's only one result
+		if (count($movies) === 1 && $filterForm->name === $movies[0]->label)
+			$this->redirect(['details', 'id' => $movies[0]->getId()]);
+
+		$dataProvider = new LibraryDataProvider($movies);
+		$dataProvider->makeSortable();
+
+		$this->render('index', [
+			'dataProvider' => $dataProvider,
+			'filterForm'   => $filterForm,
+		]);
 	}
-	
+
+
 	/**
 	 * Renders a list of recently added movies
 	 */
 	public function actionRecentlyAdded()
 	{
 		$movies = VideoLibrary::getRecentlyAddedMovies();
+
+		$dataProvider = new LibraryDataProvider($movies);
+		$dataProvider->makeSortable();
+		$dataProvider->sort->defaultOrder = 'dateadded DESC';
 		
 		$this->render('recentlyAdded', array(
-			'dataProvider'=>new LibraryDataProvider($movies)));
+			'dataProvider'=> $dataProvider
+		));
 	}
 	
 	/**

--- a/src/protected/controllers/TvShowController.php
+++ b/src/protected/controllers/TvShowController.php
@@ -34,10 +34,18 @@ class TvShowController extends MediaController
 		// Get the appropriate request parameters from the filter
 		$filterForm = new TVShowFilterForm();
 		$tvshows = VideoLibrary::getTVShows($filterForm->buildRequestParameters());
-		
-		$this->renderIndex($tvshows, $filterForm);
+
+		// Redirect to the details page if this is the only TV show
+		if (count($tvshows) === 1 && $filterForm->name === $tvshows[0]->label)
+			$this->redirect(['details', 'id' => $tvshows[0]->getId()]);
+
+		$this->render('index', [
+			'dataProvider' => new LibraryDataProvider($tvshows),
+			'filterForm'   => $filterForm,
+		]);
 	}
-	
+
+
 	/**
 	 * Displays information about the specified show
 	 * @param int $id the show ID

--- a/src/protected/widgets/results/ResultGrid.php
+++ b/src/protected/widgets/results/ResultGrid.php
@@ -24,10 +24,6 @@ class ResultGrid extends CListView
 			location.hash = '#result-list';
 			$('.lazy').unveil();
 		}");
-		
-		if ($this->dataProvider instanceof LibraryDataProvider) {
-			$this->dataProvider->makeSortable();	
-		}
 	}
 
 	/**

--- a/src/protected/widgets/results/ResultList.php
+++ b/src/protected/widgets/results/ResultList.php
@@ -22,10 +22,6 @@ abstract class ResultList extends TbGridView
 	{
 		// Configure columns
 		$this->columns = $this->getColumnDefinitions();
-
-		if ($this->dataProvider instanceof LibraryDataProvider) {
-			$this->dataProvider->makeSortable();
-		}
 	}
 	
 	/**


### PR DESCRIPTION
This way we can change the default sort order for the recently added page. 

Fixes #296. @amilino can you test this? It should fix the default order of the recently added movies page while still allowing it to be sorted.