### PR TITLE
Sort movies and TV shows by "premiered" instead of "year"

### DIFF
--- a/src/protected/models/VideoLibrary.php
+++ b/src/protected/models/VideoLibrary.php
@@ -18,14 +18,14 @@ class VideoLibrary
 	 * @var string[] default properties for movies
 	 */
 	private static $_defaultMovieProperties = array(
-		'year', 'genre', 'thumbnail', 'rating', 'runtime', 'playcount', 'dateadded'
+		'year', 'genre', 'thumbnail', 'rating', 'runtime', 'playcount', 'dateadded', 'premiered'
 	);
 
 	/**
 	 * @var string[] default properties for TV shows
 	 */
 	private static $_defaultTVShowProperties = array(
-		'year', 'genre', 'thumbnail', 'art', 'playcount',
+		'year', 'genre', 'thumbnail', 'art', 'playcount', 'premiered',
 	);
 
 	/**

--- a/src/protected/models/json/HasPremieredTrait.php
+++ b/src/protected/models/json/HasPremieredTrait.php
@@ -27,7 +27,7 @@ trait HasPremieredTrait
 
 		// Year is usually zero or 1601 when it's not available
 		if ($this->year !== 0 && $this->year !== 1601)
-			echo $this->year;
+			return $this->year;
 
 		// If nothing is available
 		return Yii::t('Misc', 'Not available');

--- a/src/protected/models/json/HasPremieredTrait.php
+++ b/src/protected/models/json/HasPremieredTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+trait HasPremieredTrait
+{
+
+	/**
+	 * @var string the date the movie premiered
+	 */
+	public $premiered;
+
+
+	/**
+	 * @return string|int
+	 */
+	public function getRenderedYear()
+	{
+		// If premiered is available we use the year from that
+		if ($this->premiered !== '')
+		{
+			$premiereDate = DateTime::createFromFormat('Y-m-d', $this->premiered);
+
+			if ($premiereDate !== false)
+			{
+				return $premiereDate->format('Y');
+			}
+		}
+
+		// Year is usually zero or 1601 when it's not available
+		if ($this->year !== 0 && $this->year !== 1601)
+			echo $this->year;
+
+		// If nothing is available
+		return Yii::t('Misc', 'Not available');
+	}
+}

--- a/src/protected/models/json/Movie.php
+++ b/src/protected/models/json/Movie.php
@@ -13,6 +13,7 @@
  */
 class Movie extends File implements IStreamable
 {
+	use HasPremieredTrait;
 
 	/**
 	 * @var int

--- a/src/protected/models/json/TVShow.php
+++ b/src/protected/models/json/TVShow.php
@@ -10,6 +10,7 @@
 class TVShow extends Media implements IStreamable
 {
 	use StreamableTrait;
+	use HasPremieredTrait;
 
 	/**
 	 * @var object

--- a/src/protected/widgets/results/ResultList.php
+++ b/src/protected/widgets/results/ResultList.php
@@ -49,13 +49,12 @@ abstract class ResultList extends TbGridView
 	protected function getYearColumn()
 	{
 		return array(
-			'name'=>'year',
+			'name'=>'premiered',
 			'header'=>Yii::t('GenericList', 'Year'),
 			'value'=>function($data) {
-				// Year is zero when it's not available
-				if ($data->year !== 0)
-					echo $data->year;
-			}
+				/** @var Movie|TVShow $data */
+				echo $data->getRenderedYear();
+			},
 		);
 	}
 


### PR DESCRIPTION
This also changes the rendering of the year to use the year from the premiere date when it's available, otherwise the "year" column, and if nothing is available, "Not available" is returned. This also fixes a bug where 1601 is shown as the year for items that don't apparently have a year (Kodi sometimes returns 1601 instead of 0).

Closes #317

@amilino can you try this branch? Please note that the query parameters have changed from e.g.`?sort=year.desc` to `?sort=premiered.desc`.