### PR TITLE
Add much better support for MySQL

### DIFF
--- a/.env.mysql.example
+++ b/.env.mysql.example
@@ -1,0 +1,5 @@
+USE_MYSQL=true
+MYSQL_HOSTNAME=localhost
+MYSQL_DATABASE=xbmc_video_server
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=root

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ whitelist.override
 /node_modules
 /.vagrant
 /ubuntu-bionic-18.04-cloudimg-console.log
+.env
 **/.idea/workspace.xml
 **/.idea/tasks.xml

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,23 @@
 {
     "require": {
         "php": ">=5.4",
-        "yiisoft/yii": "1.1.20",
-        "jalle19/simple-json-rpc-client": ">=1.0.9",
-        "jalle19/php-whitelist-check": "1.0.*",
-        "jalle19/yii-lazy-image": "1.0.*",
-        "crisu83/yiistrap": "1.2.*",
-        "crisu83/yii-consoletools": "1.0.*",
         "behat/transliterator": "1.0.*",
+        "crisu83/yii-consoletools": "1.0.*",
+        "crisu83/yiistrap": "1.2.*",
         "gavroche/browser": "2.2.*",
         "hautelook/phpass": "0.3.*",
+        "hoa/websocket": "2.15.08.05",
+        "imagine/imagine": "0.6.*",
+        "jalle19/php-whitelist-check": "1.0.*",
+        "jalle19/simple-json-rpc-client": ">=1.0.9",
+        "jalle19/xsphpf": "^1.0",
+        "jalle19/yii-lazy-image": "1.0.*",
         "mobiledetect/mobiledetectlib": "2.7.*",
         "netresearch/jsonmapper": "0.8.*",
         "tomnomnom/phpwol": "0.1.*",
-        "zendframework/zend-http": "2.2.*",
-        "imagine/imagine": "0.6.*",
-        "hoa/websocket": "2.15.08.05",
-        "jalle19/xsphpf": "^1.0"
+        "vlucas/phpdotenv": "^3.4",
+        "yiisoft/yii": "1.1.20",
+        "zendframework/zend-http": "2.2.*"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f3548d216afd0bed30a026cd0a59081",
+    "content-hash": "1aacc15923f59634b58f33c5ba7288ad",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -846,6 +846,114 @@
             "time": "2015-07-06T07:43:26+00:00"
         },
         {
+            "name": "phpoption/phpoption",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpOption\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "time": "2015-07-25T16:39:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
             "name": "tomnomnom/phpwol",
             "version": "0.1.0",
             "source": {
@@ -882,6 +990,58 @@
             "description": "Wake On LAN for PHP",
             "homepage": "https://github.com/TomNomNom/phpwol/",
             "time": "2015-11-24T12:57:42+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "5084b23845c24dbff8ac6c204290c341e4776c92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/5084b23845c24dbff8ac6c204290c341e4776c92",
+                "reference": "5084b23845c24dbff8ac6c204290c341e4776c92",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0",
+                "phpoption/phpoption": "^1.5",
+                "symfony/polyfill-ctype": "^1.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2019-06-15T22:40:20+00:00"
         },
         {
             "name": "xrstf/ip-utils",

--- a/provisioning/02-install-system-packages.sh
+++ b/provisioning/02-install-system-packages.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 {
+    # configure debconf for mysql-server
+    echo "mysql-server mysql-server/root_password password root" | debconf-set-selections
+    echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections
+
     # install dependencies
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
     DEBIAN_FRONTEND=noninteractive apt-get -y install libapache2-mod-php php-imagick php-cli php-sqlite3 \
-                       php-json php-xdebug curl nodejs npm unzip
+                       php-json php-xdebug curl nodejs npm unzip mysql-server php-mysql
 } > /dev/null 2>&1

--- a/src/index.php
+++ b/src/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // change the following path if necessary
-$yii=dirname(__FILE__).'/../vendor/yiisoft/yii/framework/yii.php';
-$config=dirname(__FILE__).'/protected/config/main.php'; 
+$yii    = __DIR__ . '/../vendor/yiisoft/yii/framework/yii.php';
+$config = __DIR__ . '/protected/config/main.php';
 
 // remove the following lines when in production mode
 //defined('YII_DEBUG') or define('YII_DEBUG',true);
@@ -10,12 +10,12 @@ $config=dirname(__FILE__).'/protected/config/main.php';
 //defined('YII_TRACE_LEVEL') or define('YII_TRACE_LEVEL',3);
 
 // include Composer's autoloader
-require_once(__DIR__.'/../vendor/autoload.php');
+require_once __DIR__ . '/../vendor/autoload.php';
 
 // increase memory limit and execution time
 ini_set('memory_limit', '1024M');
 ini_set('max_execution_time', 120);
 
-require_once($yii);
+require_once $yii;
 
 Yii::createWebApplication($config)->run();

--- a/src/index.php
+++ b/src/index.php
@@ -1,5 +1,8 @@
 <?php
 
+// include Composer's autoloader
+require_once __DIR__ . '/../vendor/autoload.php';
+
 // change the following path if necessary
 $yii    = __DIR__ . '/../vendor/yiisoft/yii/framework/yii.php';
 $config = __DIR__ . '/protected/config/main.php';
@@ -8,9 +11,6 @@ $config = __DIR__ . '/protected/config/main.php';
 //defined('YII_DEBUG') or define('YII_DEBUG',true);
 // specify how many levels of call stack should be shown in each log message
 //defined('YII_TRACE_LEVEL') or define('YII_TRACE_LEVEL',3);
-
-// include Composer's autoloader
-require_once __DIR__ . '/../vendor/autoload.php';
 
 // increase memory limit and execution time
 ini_set('memory_limit', '1024M');

--- a/src/index.php
+++ b/src/index.php
@@ -3,6 +3,11 @@
 // include Composer's autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
 
+if (file_exists(__DIR__.'/../.env')) {
+	$dotenv = \Dotenv\Dotenv::create(__DIR__ . '/..');
+	$dotenv->load();
+}
+
 // change the following path if necessary
 $yii    = __DIR__ . '/../vendor/yiisoft/yii/framework/yii.php';
 $config = __DIR__ . '/protected/config/main.php';

--- a/src/protected/commands/CreateInitialDatabaseCommand.php
+++ b/src/protected/commands/CreateInitialDatabaseCommand.php
@@ -16,14 +16,20 @@ class CreateInitialDatabaseCommand extends CConsoleCommand
 	 */
 	public function actionIndex()
 	{
-		$schema = file_get_contents(realpath(__DIR__
-						.'/../data/schema.sqlite.sql'));
+		// Determine which schema to use
+		$schemaFile = getenv('USE_MYSQL') === 'true' ? 'schema.mysql.sql' : 'schema.sqlite.sql';
+		$schema = file_get_contents(realpath(__DIR__ .'/../data/'.$schemaFile));
 
 		// Execute each command in the schema one by one
 		$commands = explode(';', $schema);
 
-		foreach (array_filter($commands) as $command)
-			Yii::app()->db->createCommand(trim($command))->execute();
+		foreach (array_filter($commands) as $command) {
+			// MySQL doesn't like empty queries
+			$command = trim($command);
+			
+			if ($command !== '') {
+				Yii::app()->db->createCommand(trim($command))->execute();
+			}
+		}
 	}
-
 }

--- a/src/protected/config/_db.php
+++ b/src/protected/config/_db.php
@@ -1,19 +1,26 @@
 <?php
 
-// return the configuration for the 'db' application component
-return array(
-	'connectionString' => 'sqlite:'.__DIR__.'/../data/xbmc-video-server.db',
-	'schemaCachingDuration'=>0, // 30 days
-);
+// Return SQLite configuration unless the USE_MYSQL environment variable is set to true (mostly for advanced Docker 
+// usage)
+if (getenv('USE_MYSQL') !== 'true')
+{
+	return [
+		'connectionString'      => 'sqlite:' . __DIR__ . '/../data/xbmc-video-server.db',
+		'schemaCachingDuration' => 0, // 30 days
+	];
+}
 
-// To use MySQL instead of SQLite, use something like this instead. You will 
-// then have to configure the settings below to match your setup and run the 
-// file schema.mysql.sql to setup the initial database.
-//return array(
-//	'connectionString' => 'mysql:host=localhost;dbname=xbmc_video_server',
-//	'emulatePrepare' => true,
-//	'username' => 'root',
-//	'password' => '',
-//	'charset' => 'utf8',
-//	'schemaCachingDuration' => 3600,
-//);
+// MySQL configuration. Use schema.mysql.sql to setup the initial database
+$hostname = getenv('MYSQL_HOSTNAME');
+$database = getenv('MYSQL_DATABASE');
+$user     = getenv('MYSQL_USERNAME');
+$password = getenv('MYSQL_PASSWORD');
+
+return [
+	'connectionString'      => "mysql:host=$hostname;dbname=$database",
+	'emulatePrepare'        => true,
+	'username'              => $user,
+	'password'              => $password,
+	'charset'               => 'utf8',
+	'schemaCachingDuration' => 3600,
+];

--- a/src/protected/config/main.php
+++ b/src/protected/config/main.php
@@ -58,7 +58,7 @@ return array(
 		'backendManager'=>array(
 			'class'=>'BackendManager',
 		),
-		'db'=>require_once('_db.php'),
+		'db'=>require '_db.php',
 		'xbmc'=>array(
 			'class'=>'XBMC',
 		),

--- a/src/protected/data/schema.mysql.sql
+++ b/src/protected/data/schema.mysql.sql
@@ -21,7 +21,7 @@ CREATE TABLE `user` (
 	`username` VARCHAR(255) NOT NULL, 
 	`password` VARCHAR(255) NOT NULL,
 	`language` VARCHAR(255),
-	`start_page` VARCHAR(255),
+	`start_page` VARCHAR(255)
 );
 
 INSERT INTO `user` (`role`,`username`,`password`,`language`) VALUES('admin','admin','admin',NULL);

--- a/src/protected/yiic.php
+++ b/src/protected/yiic.php
@@ -1,8 +1,13 @@
 <?php
 
-// load environment from .env if it exists
 // include Composer's autoloader
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// load environment from .env if it exists
+if (file_exists(__DIR__ . '/../../.env')) {
+	$dotenv = \Dotenv\Dotenv::create(__DIR__ . '/../..');
+	$dotenv->load();
+}
 
 // change the following paths if necessary
 $yiic   = __DIR__ . '/../../vendor/yiisoft/yii/framework/yiic.php';

--- a/src/protected/yiic.php
+++ b/src/protected/yiic.php
@@ -2,10 +2,10 @@
 
 // load environment from .env if it exists
 // include Composer's autoloader
-require_once __DIR__.'/../../vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 // change the following paths if necessary
-$yiic=dirname(__FILE__).'/../../vendor/yiisoft/yii/framework/yiic.php';
-$config=dirname(__FILE__).'/config/console.php';
+$yiic   = __DIR__ . '/../../vendor/yiisoft/yii/framework/yiic.php';
+$config = __DIR__ . '/config/console.php';
 
 require_once($yiic);

--- a/src/protected/yiic.php
+++ b/src/protected/yiic.php
@@ -1,5 +1,9 @@
 <?php
 
+// load environment from .env if it exists
+// include Composer's autoloader
+require_once __DIR__.'/../../vendor/autoload.php';
+
 // change the following paths if necessary
 $yiic=dirname(__FILE__).'/../../vendor/yiisoft/yii/framework/yiic.php';
 $config=dirname(__FILE__).'/config/console.php';


### PR DESCRIPTION
It should now be possible to use MySQL over SQLite without modifying the code, by setting the following environment variables:

```
USE_MYSQL=true
MYSQL_HOSTNAME=
MYSQL_DATABASE=
MYSQL_USERNAME=
MYSQL_PASSWORD=
```

The easiest way to set them is to `cp .env.mysql.example .env` in the project root directory. There is more information available here: https://github.com/Jalle19/xbmc-video-server/wiki/Using-MySQL-instead-of-SQLite

Closes #320